### PR TITLE
[Fix]更新search.ejs,适配使用子目录的博客

### DIFF
--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -134,7 +134,7 @@
       };
     
       // use atom.xml to search blog
-      searchFunc("/atom.xml", "local-search-input", "local-search-result");
+      searchFunc("<%- config.root %>atom.xml", "local-search-input", "local-search-result");
       $("#searchModalCenter").on("shown.bs.modal", function(e) {
         setTimeout(function() {
           $("#local-search-input").focus();


### PR DESCRIPTION
之前search.ejs是把 `/atom.xml` 写死了，修改后增加前缀，改为 `<%- config.root %>atom.xml`