### PR TITLE
又有新功能了，请查收哦

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,3 +21,8 @@ local_search: true
 # using viewer.js to view image
 # https://fengyuanchen.github.io/viewerjs/
 image_viewer: true
+
+# Table of content
+# Maybe support more toc style in future.
+toc:
+  enable: true

--- a/layout/_partial/article-full.ejs
+++ b/layout/_partial/article-full.ejs
@@ -37,7 +37,9 @@
                                                     <% } %>
                                 </div>
                                 <div class="post-date">
-                                    <%- item.date.format(config.date_format || theme.date_format) %>
+                                    <% if (item.date){ %>
+                                        <%- item.date.format(config.date_format || theme.date_format) %>
+                                    <% } %>
                                 </div>
                             </div>
                     </div>
@@ -53,3 +55,6 @@
 
 <!-- Image viewer-->
 <%- partial('_partial/img-viewer') %>
+
+<!-- TOC -->
+<%- partial("_partial/toc", {post: item}) %>

--- a/layout/_partial/toc.ejs
+++ b/layout/_partial/toc.ejs
@@ -1,0 +1,7 @@
+<% if (theme.toc.enable){ %>
+    <aside id="article-toc" role="navigation" class="fixed">
+        <div id="article-toc-inner">
+            <%- toc(post.content, {list_number: true}) %>
+        </div>
+    </aside>
+<% } %>

--- a/source/css/darkmode.styl
+++ b/source/css/darkmode.styl
@@ -1,0 +1,45 @@
+@media (prefers-color-scheme: dark) {
+    // change color here
+    :root {
+        --bg-color: #1b1c1c;
+        --font-color: #c9c0b0;
+        --line-color: #3b3e3d;
+    }
+
+    // icon
+    .fa-camera-retro, .fa-search, .fa-puzzle-piece {
+        color: var(--font-color);
+    }
+
+    // post preview, title, article content...
+    body, .intro, .post-title, .post-preview a p, .post-heading h1 {
+        background: var(--bg-color);
+        color: var(--font-color);
+    }
+
+    // code block
+    figure.highlight {
+        background-color: var(--bg-color);
+        color: var(--font-color);
+        border-color: var(--line-color);
+        text-shadow: var(--bg-color) 0px 0px 1px;
+    }
+    figure.highlight table .line {
+        color: var(--font-color);
+    }
+
+    // code inline
+    code {
+        color: #df5874;
+        background-color: #2c171b;
+    }
+
+    // image opacity
+    article .container .row img {
+        opacity: .7;
+        transition: opacity .5s ease-in-out;
+    }
+    article .container .row img:hover {
+        opacity: 1;
+    }
+}

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -3,3 +3,5 @@
 @import "article.styl"
 @import "more.styl"
 @import "custom.styl"
+@import "toc.styl"
+@import "darkmode.styl"

--- a/source/css/toc.styl
+++ b/source/css/toc.styl
@@ -1,0 +1,45 @@
+#article-toc-inner:after,#article-toc-inner:before,.inner:after,.inner:before {
+    content: "";
+    display: table
+}
+
+#article-toc-inner:after,.inner:after {
+    clear: both
+}
+
+@media screen {
+    #article-toc-inner,.inner {
+        padding: 0 20px
+    }
+}
+#article-toc {
+    display: none;
+    float: right;
+    width: 16%;
+    margin-right: -220px;
+    opacity: .8
+}
+@media screen and (min-width:986px) {
+    #article-toc {
+        display: block
+    }
+}
+#article-toc.fixed {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 220px;
+    padding-top: 55px;
+}
+.fixed #article-toc-inner {
+    position: fixed;
+    width: 220px;
+    top: 0;
+    bottom: 0;
+    padding-top: 10%;
+}
+#article-toc-inner ol {
+    margin-left: -16px;
+    list-style: none;
+    font-size: 11px;
+}


### PR DESCRIPTION
[New Feature] 
1. 支持文章目录
2. 支持深色模式
3. 修复data format在hexo generate编译时报错信息

---

**文章目录：**
主题配置中可选配置：
```
toc:
  enable: true
```

效果图：
[demo](https://foreti.me/blog/2021/03/15/setup-env-on-mac/)
![image](https://user-images.githubusercontent.com/30440198/112727597-2a0b1800-8f5e-11eb-9700-a6a95511f3a2.png)

---

**深色模式：**

站点可以根据客户端的系统配置的黑暗模式（深色模式）是否开启，加载对应的 light or dark css属性。

目前不支持主题配置开关，因为不知道如何在styl中加载配置=,=。

效果图：

浅色模式（默认）：
![image](https://user-images.githubusercontent.com/30440198/112727646-6c345980-8f5e-11eb-8586-1adcce8f13f9.png)

深色模式：
![image](https://user-images.githubusercontent.com/30440198/112727657-77878500-8f5e-11eb-8f7d-96fc6ed97a1d.png)

![image](https://user-images.githubusercontent.com/30440198/112727771-085e6080-8f5f-11eb-934a-8c8a74236017.png)

深色模式下图片设置透明度：
![image](https://user-images.githubusercontent.com/30440198/112727805-275cf280-8f5f-11eb-9a2e-86612db55cdd.png)
鼠标hover时恢复正常：
![image](https://user-images.githubusercontent.com/30440198/112727808-2af07980-8f5f-11eb-8bc1-42e4e621f7ca.png)

---

**修复一个编译时的错误信息：**

![image](https://user-images.githubusercontent.com/30440198/112727669-8bcb8200-8f5e-11eb-8fa2-e311f30305aa.png)

该错误看起来是由于最近一次的[date format相关提交](https://github.com/zchen9/hexo-theme-hollow/commit/e6a1c0daa80825acf436de845a911d31721d36a6)导致。
